### PR TITLE
fix: change menu items order, activate persons module and name it Infrastructure

### DIFF
--- a/frontend/app/(container)/communities/page.tsx
+++ b/frontend/app/(container)/communities/page.tsx
@@ -9,8 +9,8 @@ import {getCommunityList} from '~/components/communities/apiCommunities'
 import CommunitiesOverviewClient from '~/components/communities/overview'
 
 export const metadata: Metadata = {
-  title: `Communities | ${app.title}`,
-  description: 'List of RSD communities.'
+  title: `EU Projects | ${app.title}`,
+  description: 'List of EU projects.'
 }
 
 export default async function CommunitiesOverviewPage({

--- a/frontend/components/communities/overview/index.tsx
+++ b/frontend/components/communities/overview/index.tsx
@@ -42,7 +42,7 @@ export default function CommunitiesOverview({
         </h1>
         <div className="flex-2 flex min-w-[20rem]">
           <SearchInput
-            placeholder="Search community by name or short description"
+            placeholder="Search by name or short description"
             onSearch={(search: string) => handleQueryChange('search', search)}
             defaultValue={search ?? ''}
           />

--- a/frontend/components/home/eqd/LogoSection.tsx
+++ b/frontend/components/home/eqd/LogoSection.tsx
@@ -5,6 +5,7 @@
 
 import LogoSURF from '~/assets/logos/LogoSurf.svg'
 import LogoLRZ from '~/assets/logos/LogoLRZ.svg'
+import LogoNLEsc from '~/assets/logos/LogoEscience.svg'
 
 export default function LogoSection() {
   return (
@@ -15,19 +16,20 @@ export default function LogoSection() {
         Partners supporting the European Quantum Directory
       </div>
       <div
-        className="flex gap-10 w-full flex-wrap mt-6 p-3 items-center opacity-30">
-        <LogoSURF className="max-h-[4rem]"/>
-        <LogoLRZ className = "max-h-[4rem]" />
+        className="flex gap-12 w-full flex-wrap mt-6 p-3 items-center opacity-30">
+        <LogoSURF className="max-h-[3rem]"/>
+        <LogoLRZ className = "max-h-[3rem]" />
         {/* Euro-Q-HPCI logo */}
         <img
-          style={{maxHeight:'4rem'}}
+          style={{maxHeight:'3rem'}}
           src="/images/euro-q-hpci.png" alt="euro-q-hpci logo"
         />
         {/* QEX logo */}
         <img
-          style={{maxHeight:'4rem'}}
+          style={{maxHeight:'3rem'}}
           src="/images/qex.png" alt="qex logo"
         />
+        <LogoNLEsc className = "max-h-[2.5rem]" />
       </div>
     </div>
   )

--- a/frontend/components/profile/overview/index.tsx
+++ b/frontend/components/profile/overview/index.tsx
@@ -34,11 +34,11 @@ export default function PersonsOverviewClient({pages,page,rows,search,persons}:P
       {/* Page header */}
       <div className="flex flex-wrap mt-4 py-8 px-4 rounded-lg bg-base-100 lg:sticky top-0 border border-base-200 z-11">
         <h1 className="mr-4 lg:flex-1">
-          Persons
+          Infrastucture
         </h1>
         <div className="flex-2 flex min-w-[20rem]">
           <SearchInput
-            placeholder="Search person by name or affiliation"
+            placeholder="Search by name or keyword"
             onSearch={(search: string) => handleQueryChange('search', search)}
             defaultValue={search ?? undefined}
           />

--- a/frontend/config/menuItems.tsx
+++ b/frontend/config/menuItems.tsx
@@ -24,7 +24,7 @@ import {RsdModuleName} from './rsdSettingsReducer'
 export type MenuModules = RsdModuleName | 'user'
 
 export type MenuItemType = {
-  type?: 'link' | 'function' |'divider' | 'pluginSlot'
+  type?: 'link' | 'function' |'divider' | 'pluginSlot' | 'module'
   label: string,
   // used as url link
   path?: string,

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/public/data/settings.json
+++ b/frontend/public/data/settings.json
@@ -1,14 +1,14 @@
 {
   "host": {
     "name": "eqd",
-    "email": "ariana.torres@surf.nl",
+    "email": "info@eqd.eu",
     "emailHeaders": [],
-    "logo_url": "/images/SURF_logo.svg",
+     "logo_url": null,
     "website": "https://www.surf.nl/",
     "feedback": {
       "enabled": true,
       "host_label": "EQD",
-      "url": "ariana.torres@surf.nl",
+      "url": "info@eqd.eu",
       "issues_page_url": "https://github.com/research-software-directory/EQD/issues"
     },
     "login_info_url":"https://research-software-directory.github.io/documentation/getting-access.html",
@@ -20,6 +20,16 @@
     "orcid_search":true
   },
   "modules":{
+    "communities": {
+      "active":true,
+      "name":"communities",
+      "menuItem":"Communities"
+    },
+    "persons": {
+      "active":true,
+      "name":"persons",
+      "menuItem": "Infrastructure"
+    },
     "projects":{
       "active":true,
       "name":"projects",
@@ -34,16 +44,6 @@
       "active":true,
       "name":"organisations",
       "menuItem":"Organisations"
-    },
-    "communities": {
-      "active":true,
-      "name":"communities",
-      "menuItem":"EU Projects"
-    },
-    "persons": {
-      "active":false,
-      "name":"persons",
-      "menuItem": "Persons"
     },
     "news": {
       "active":true,


### PR DESCRIPTION
# Homepage adjustments

Closes #7

Changes proposed in this pull request:
* Change menu items order
* Add Infrastructure menu item
* Remove logo from footer
* Add eScience to logo section     

How to test:
* `make start` to build and generate test data
* Observe mentioned changes

## Example homepage and menu items
<img width="1695" height="3650" alt="image" src="https://github.com/user-attachments/assets/51f8c4df-dd17-4a90-8e2e-11584de0cc98" />


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
