### PR TITLE
fix: organisation default tab and upgrade fe changes to rsd v6.1.0

### DIFF
--- a/frontend/app/(base)/add/layout.tsx
+++ b/frontend/app/(base)/add/layout.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // force to be dynamic route
 export const dynamic = 'force-dynamic'
@@ -16,7 +20,7 @@ export default function AddLayout({
 }>) {
 
   return (
-    <article className="flex-1 pt-12">
+    <article className="flex-1 p-4 lg:pt-12">
       {children}
     </article>
   )

--- a/frontend/app/(container)/organisations/[...slug]/page.tsx
+++ b/frontend/app/(container)/organisations/[...slug]/page.tsx
@@ -31,8 +31,16 @@ export default async function OrganisationPage({
     getActiveModuleNames()
   ])
 
-  const tab = query?.['tab'] ?? modules[0] as TabKey
-  // const layout = rsd_page_layout === 'masonry' ? 'grid' : rsd_page_layout
+  let tab:TabKey
+  if (query?.['tab']){
+    tab=query?.['tab'] as TabKey
+  } else if (modules.includes('software')){
+    tab = 'software'
+  } else if (modules.includes('projects')){
+    tab = 'projects'
+  } else {
+    tab = 'releases'
+  }
 
   // console.group('OrganisationPage')
   // console.log('slug...', slug)

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -31,6 +32,13 @@ import Announcement from '~/components/Announcement/Announcement'
 import ProgressProviderApp from '~/components/bprogress/ProgressProviderApp'
 
 import '~/styles/global.css'
+
+export const viewport = {
+  // Matches 30rem defined in global.css
+  width: 480,
+  // Do not use initialScale to allow smartphone to scale it properly
+  initialScale: -1,
+}
 
 export const metadata: Metadata = {
   title: 'Home',

--- a/frontend/components/admin/package-manager/AdminPacManListItem.tsx
+++ b/frontend/components/admin/package-manager/AdminPacManListItem.tsx
@@ -1,13 +1,14 @@
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import IconButton from '@mui/material/IconButton'
-import ListItem from '@mui/material/ListItem'
 import DeleteIcon from '@mui/icons-material/Delete'
 import EditIcon from '@mui/icons-material/Edit'
 
+import ListItemWithAction from '~/components/layout/ListItemWithAction'
 import {PackageManager} from '~/components/software/edit/package-managers/apiPackageManager'
 import PackageManagerItemBody from '~/components/software/edit/package-managers/PackageManagerItemBody'
 
@@ -19,7 +20,7 @@ type AdminPacManListItemProps=Readonly<{
 
 export default function AdminPacManListItem({item,onEdit,onDelete}:AdminPacManListItemProps) {
   return (
-    <ListItem
+    <ListItemWithAction
       secondaryAction={
         <>
           <IconButton
@@ -46,6 +47,6 @@ export default function AdminPacManListItem({item,onEdit,onDelete}:AdminPacManLi
       }
     >
       <PackageManagerItemBody item={item} />
-    </ListItem>
+    </ListItemWithAction>
   )
 }

--- a/frontend/components/admin/package-manager/index.tsx
+++ b/frontend/components/admin/package-manager/index.tsx
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -23,7 +24,7 @@ export default function AdminRepositories() {
   return (
     <SearchProvider>
       <PaginationProvider pagination={pagination}>
-        <section className="flex-1">
+        <section className="flex-1 overflow-hidden">
           <div className="flex flex-wrap items-center justify-end">
             <Searchbox />
             <Pagination />

--- a/frontend/components/admin/repositories/AdminRepoListItem.tsx
+++ b/frontend/components/admin/repositories/AdminRepoListItem.tsx
@@ -1,13 +1,14 @@
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import IconButton from '@mui/material/IconButton'
-import ListItem from '@mui/material/ListItem'
 import DeleteIcon from '@mui/icons-material/Delete'
 import EditIcon from '@mui/icons-material/Edit'
 
+import ListItemWithAction from '~/components/layout/ListItemWithAction'
 import {RepositoryUrl} from '~/components/software/edit/repositories/apiRepositories'
 import RepositoryItemContent from '~/components/software/edit/repositories/RepositoryItemContent'
 
@@ -19,7 +20,7 @@ type AdminRepoListItemProps=Readonly<{
 
 export default function AdminRepoListItem({item,onEdit,onDelete}:AdminRepoListItemProps) {
   return (
-    <ListItem
+    <ListItemWithAction
       secondaryAction={
         <>
           <IconButton
@@ -46,6 +47,6 @@ export default function AdminRepoListItem({item,onEdit,onDelete}:AdminRepoListIt
       }
     >
       <RepositoryItemContent item={item}/>
-    </ListItem>
+    </ListItemWithAction>
   )
 }

--- a/frontend/components/admin/repositories/index.tsx
+++ b/frontend/components/admin/repositories/index.tsx
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -23,7 +24,7 @@ export default function AdminRepositories() {
   return (
     <SearchProvider>
       <PaginationProvider pagination={pagination}>
-        <section className="flex-1">
+        <section className="flex-1 overflow-hidden">
           <div className="flex flex-wrap items-center justify-end">
             <Searchbox />
             <Pagination />

--- a/frontend/components/layout/EditPageButton.tsx
+++ b/frontend/components/layout/EditPageButton.tsx
@@ -6,7 +6,8 @@
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
-
+'use client'
+import Link from 'next/link'
 import EditIcon from '@mui/icons-material/Edit'
 import Button from '@mui/material/Button'
 import EditFab from './EditFab'
@@ -66,8 +67,7 @@ export default function EditPageButton({title, url, isMaintainer, variant}: Edit
             // minWidth: '6rem'
           }}
           href={url}
-          // this causes unexpected error after upgrade to v16
-          // LinkComponent={Link}
+          LinkComponent={Link}
         >
           {/* Edit page */}
           {title}

--- a/frontend/components/layout/ListItemWithAction.tsx
+++ b/frontend/components/layout/ListItemWithAction.tsx
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import ListItem, {ListItemProps} from '@mui/material/ListItem'
+/**
+ * ListItemWithAction changes the layout of list component. Instead of having secondaryAction
+ * component at absolute position we use it relative element in the flex. This ensures that
+ * button area is automatically resized to fix action buttons. Default layout is optimized for only 1 button
+ */
+export default function ListItemWithAction({children,secondaryAction,...otherProps}:ListItemProps) {
+  return (
+    <ListItem
+      sx={{
+        paddingLeft:'8px',
+        paddingRight: '8px',
+        '.MuiListItemSecondaryAction-root':{
+          display: 'flex',
+          position: 'relative',
+          right: 'auto',
+          transform: 'none',
+          top: 'inherit'
+        }
+      }}
+      secondaryAction={secondaryAction}
+      {...otherProps}
+    >
+      {children}
+    </ListItem>
+  )
+}

--- a/frontend/components/layout/ViewPageButton.tsx
+++ b/frontend/components/layout/ViewPageButton.tsx
@@ -6,10 +6,10 @@
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
-
+'use client'
+import Link from 'next/link'
 import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined'
 import Button from '@mui/material/Button'
-import Link from 'next/link'
 
 type ViewButtonProps = {
   title: string,

--- a/frontend/styles/global.css
+++ b/frontend/styles/global.css
@@ -4,8 +4,9 @@
  * SPDX-FileCopyrightText: 2022 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
  * SPDX-FileCopyrightText: 2022 Marc Hanisch (GFZ) <marc.hanisch@gfz-potsdam.de>
  * SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
- * SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+ * SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
  * SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+ * SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
  *
  * SPDX-License-Identifier: Apache-2.0
  */


### PR DESCRIPTION
# Fix default organisation tab

Closes #9

Changes proposed in this pull request:
* Change the logic that determines default ogranisation tab      
* Upgraded frontend changes from main rsd up to version v6.1.0

How to test:
* `make start` to build and generate test data. Navigate to organisation overview and select an organisation. The default tab should be software if the software module is enabled, if not the projects tab should be default. If both software and projects are not enabled then releases will be default tab. In all these cases 404 page should not be shown.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
